### PR TITLE
Update study.best_trials docstring

### DIFF
--- a/optuna/study/study.py
+++ b/optuna/study/study.py
@@ -151,9 +151,8 @@ class Study:
         """Return trials located at the Pareto front in the study.
 
         A trial is located at the Pareto front if there are no trials that dominate the trial.
-        It's called that a trial ``t0`` dominates another trial ``t1`` if
-        ``all(v0 <= v1) for v0, v1 in zip(t0.values, t1.values)`` and
-        ``any(v0 < v1) for v0, v1 in zip(t0.values, t1.values)`` are held.
+        It's called that a trial ``t0`` dominates another trial ``t1`` if the condition
+        ``all(v0 <= v1) for v0, v1 in zip(t0.values, t1.values)`` is true.
 
         Returns:
             A list of :class:`~optuna.trial.FrozenTrial` objects.


### PR DESCRIPTION
## Motivation
While reading through the docs/code to understand how the pareto front is calculated in the case of multiobjective optimization, I noticed a slight inconsistency between the `Study.best_trials` documentation and the actual test that's run in `_dominates()` within `_multi_objective.py`. The documentation indicates both `all(v0 <= v1) for v0, v1 in zip(t0.values, t1.values)` and `any(v0 < v1) for v0, v1 in zip(t0.values, t1.values)` are used to check if one trial dominates the other.

Following the code to where this check is made: the `Study.best_trials` property calls `_get_pareto_front_trials` within `_multiobjective.py`.  This then calls `_get_pareto_front_trials_by_trials`, which then either calls either `_get_pareto_front_trials_2d` or `_get_pareto_front_trials_nd`. Both branches will then call the `_dominates` method, which appears to only check the `<=` condition. Looked around the rest of the codebase for calls to `any`, and I couldn't find the `any` check mentioned in the docstring being made anywhere.

## Description of the changes
This pull request upates the docstring of `study.best_trials` to reflect how the code currently checks for domination.

Also - Thanks for this awesome library! It's made hyperparameter optimization so much easier.
